### PR TITLE
[Fix] #189 홈 화면 오류수정

### DIFF
--- a/Dokgi/View/HomeView/Cell/CurrentLevelCell.swift
+++ b/Dokgi/View/HomeView/Cell/CurrentLevelCell.swift
@@ -48,18 +48,18 @@ class CurrentLevelCell: UICollectionViewCell {
     
     let hideView = UIView()
     
-    let nextLevel = UILabel().then {
+    let nextLevel = PaddingLabel(padding: UIEdgeInsets(top: 15, left: 0, bottom: 0, right: 0)).then {
         $0.font = Pretendard.bold.dynamicFont(style: .title3)
         $0.textColor = .black
     }
     
-    let currentLevel = UILabel().then {
+    let currentLevel = PaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)).then {
         $0.font = Pretendard.regular.dynamicFont(style: .callout)
         $0.textColor = .alarmSettingText
         $0.textAlignment = .center
     }
     
-    let questionMark = UILabel().then {
+    let questionMark = PaddingLabel(padding: UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)).then {
         $0.font = .systemFont(ofSize: 60, weight: .heavy)
         $0.textColor = .deepSkyBlue
         $0.text = "?"
@@ -112,8 +112,7 @@ class CurrentLevelCell: UICollectionViewCell {
         }
         
         levelView.snp.makeConstraints {
-            $0.leading.equalToSuperview()
-            $0.top.equalToSuperview()
+            $0.leading.top.equalToSuperview()
         }
         
         levelLabel.snp.makeConstraints {

--- a/Dokgi/View/HomeView/View/HomeView.swift
+++ b/Dokgi/View/HomeView/View/HomeView.swift
@@ -195,7 +195,7 @@ class HomeView: UIView {
         
         todayVersesColletionView.snp.makeConstraints {
             $0.top.equalTo(todayVersesLabel.snp.bottom).offset(14)
-            $0.bottom.equalToSuperview().offset(-63)
+            $0.bottom.equalToSuperview().offset(-43)
             $0.horizontalEdges.equalToSuperview().inset(20)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(158)

--- a/Dokgi/View/HomeView/ViewController/HomeViewController.swift
+++ b/Dokgi/View/HomeView/ViewController/HomeViewController.swift
@@ -225,6 +225,7 @@ extension HomeViewController: UICollectionViewDataSource {
             let randomVerses = viewModel.randomVerses.value
             if randomVerses.isEmpty || indexPath.item >= randomVerses.count {
                 let explainTexts = ["구절을 기록해주세요!", "오늘의 구절은 최대 5개까지 보여집니다", "매일 보여지는 구절은 기록한 구절 중 랜덤으로 보여집니다", "다른 구절을 보고 싶으시면 구절탭을 확인해주세요", "독기와 함께 오늘도 즐거운 독서와 기록 하세요"]
+                self.homeView.indicatorDots.numberOfPages = 5
                 cell.verse.text = explainTexts[indexPath.item]
             } else {
                 cell.verse.text = randomVerses[indexPath.item]

--- a/Dokgi/View/HomeView/ViewController/HomeViewController.swift
+++ b/Dokgi/View/HomeView/ViewController/HomeViewController.swift
@@ -223,7 +223,8 @@ extension HomeViewController: UICollectionViewDataSource {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TodayPassageCell.identifier, for: indexPath) as? TodayPassageCell else { return UICollectionViewCell() }
             
             let randomVerses = viewModel.randomVerses.value
-            if randomVerses.isEmpty || indexPath.item >= randomVerses.count {
+            let passages: [String] = viewModel.passages.value.map { $0.passage }
+            if passages.isEmpty || indexPath.item >= passages.count {
                 let explainTexts = ["구절을 기록해주세요!", "오늘의 구절은 최대 5개까지 보여집니다", "매일 보여지는 구절은 기록한 구절 중 랜덤으로 보여집니다", "다른 구절을 보고 싶으시면 구절탭을 확인해주세요", "독기와 함께 오늘도 즐거운 독서와 기록 하세요"]
                 self.homeView.indicatorDots.numberOfPages = 5
                 cell.verse.text = explainTexts[indexPath.item]

--- a/Dokgi/View/PassageView/ViewController/PassageViewController.swift
+++ b/Dokgi/View/PassageView/ViewController/PassageViewController.swift
@@ -58,6 +58,11 @@ final class PassageViewController: BaseLibraryAndPassageViewController {
         }
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
+        searchBar.delegate?.searchBarCancelButtonClicked?(searchBar)
+    }
+    
     override func configureUI() {
         passageCollectionView.delegate = self
         passageCollectionView.dataSource = self

--- a/Dokgi/ViewModel/HomeViewModel/HomeViewModel.swift
+++ b/Dokgi/ViewModel/HomeViewModel/HomeViewModel.swift
@@ -64,8 +64,10 @@ class HomeViewModel {
         // 구절 추가 업데이트
         CoreDataManager.shared.passageData
             .subscribe(onNext: { [weak self] passages in
-                self?.passages.accept(passages)
-                self?.loadTodayVerses()
+                DispatchQueue.main.async {
+                    self?.passages.accept(passages)
+                    self?.loadTodayVerses()
+                }
             })
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
## What is the PR? 🔍
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 -  비동기 데이터 문제
-  오늘의 구절데이터 없을 시 pageControl이 안뜬다
-  데이터 하나 있을 때 삭제해도 오늘의 구절에 남아있음
- 구절에서 검색 중에 메인으로 이동하면 현재 레벨 카드랑 퍼센트가 움직임
- 구절 짱많은데 오늘의 구절 보니까 3개뿐..
    - 구절에서 검색하면 검색 결과만 오늘의 구절로 들어가는 것 같습니다
- 다음 레벨 막혀있는 셀에서 저번에 고쳤던 것 같은데, ? 가 텍스트라서 위 아래 높이 여백이 다시 안 맞아보입니다 
- 홈 화면 한 화면에 다 안 나올 때만 드래그 되게(스크롤뷰 높이 조정 해야될 것 같습니다)

## Changes 📝
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->

## Screenshot 📷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요.(선택!) -->

|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF |![image](https://github.com/dogaegirl6mo/Dokgi/assets/161270615/0fd0f509-895d-43b5-b0e8-84594bfa8df0) <img src = "" width ="250">|

## To Reviewers 🙏
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## Related Issues 💭
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #189 
